### PR TITLE
Se añadieron Etiquetas de Contenido (contentDescription) a los botónes '+' y '-' de 'PESO'

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -121,7 +121,7 @@
                 android:id="@+id/rsHeight"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:contentDescription="@string/heightSliderDescription"
+                android:contentDescription="@string/rsHeightDescription"
                 android:stepSize="1"
                 android:valueFrom="120"
                 android:valueTo="200" />
@@ -177,12 +177,14 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginEnd="16dp"
+                    android:contentDescription="@string/btnSubtractWeightDescription"
                     app:backgroundTint="@color/background_fab" />
 
                 <com.google.android.material.floatingactionbutton.FloatingActionButton
-                    android:id="@+id/btnPlustWeight"
+                    android:id="@+id/btnPlusWeight"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:contentDescription="@string/btnPlusWeightDescription"
                     app:backgroundTint="@color/background_fab" />
 
             </androidx.appcompat.widget.LinearLayoutCompat>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,6 +4,10 @@
     <string name="female">Mujer</string>
     <string name="height">Altura</string>
     <string name="centimeters">%1$s cm</string>
-    <string name="heightSliderDescription">Slider de altura</string>
     <string name="weight">Peso</string>
+
+    <!-- Strings for contentDescriptions -->
+    <string name="rsHeightDescription">Slider de altura</string>
+    <string name="btnSubtractWeightDescription">Restar peso</string>
+    <string name="btnPlusWeightDescription">Aumentar peso</string>
 </resources>


### PR DESCRIPTION
Se añadieron Etiquetas de Contenido (contentDescription)  a los botónes '+' y '-' de 'PESO', solucionando el error de vista 'No speakable text present' que arrojaban.