### PR TITLE
Se corrigeron los warrings de los botones '+' y '-' de 'PESO'

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -178,7 +178,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginEnd="16dp"
                     android:contentDescription="@string/btnSubtractWeightDescription"
-                    app:backgroundTint="@color/background_fab" />
+                    app:backgroundTint="@color/background_fab"/>
 
                 <com.google.android.material.floatingactionbutton.FloatingActionButton
                     android:id="@+id/btnPlusWeight"

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -8,5 +8,6 @@
     <color name="background_app">#0E0B28</color>
     <color name="background_button">#EB1555</color>
     <color name="title_text">#FF8D8E98</color>
-    <color name="background_fab">#FF6200EE</color>
+    <color name="background_FAB">#FF6200EE</color>
+    <color name="background_fab">#5C6BC0</color>
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '8.0.0' apply false
-    id 'com.android.library' version '8.0.0' apply false
+    id 'com.android.application' version '8.0.1' apply false
+    id 'com.android.library' version '8.0.1' apply false
     id 'org.jetbrains.kotlin.android' version '1.8.0' apply false
 }


### PR DESCRIPTION
Se corrigeron los warrings de los botones '+' y '-' de 'PESO', cambiando los colores de 'background_fab' del archivo colors.xml